### PR TITLE
Fix legacy values from appearing in Headless Config

### DIFF
--- a/schemas/HeadlessConfig.schema.json
+++ b/schemas/HeadlessConfig.schema.json
@@ -337,9 +337,9 @@
       "enum": [
         "Private",
         "LAN",
+        "Contacts",
         "Friends",
-        "Friends",
-        "FriendsOfFriends",
+        "ContactsPlus",
         "FriendsOfFriends",
         "RegisteredUsers",
         "Anyone"

--- a/schemas/HeadlessConfig.schema.json
+++ b/schemas/HeadlessConfig.schema.json
@@ -338,9 +338,9 @@
         "Private",
         "LAN",
         "Contacts",
-        "Friends",
+        "Contacts",
         "ContactsPlus",
-        "FriendsOfFriends",
+        "ContactsPlus",
         "RegisteredUsers",
         "Anyone"
       ]


### PR DESCRIPTION
After my recent mess up with the wiki and legacy values (sorry about that!) I've decided to open this pull request to try and help fix the issue where it stems from (and hopefully stop anyone from making the same mistake I did). 